### PR TITLE
MNT: Update to v1 recipe format 

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,19 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +65,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,4 +3,6 @@ github:
   tooling_branch_name: main
 conda_build:
   error_overlinking: true
+conda_install_tool: pixi
+conda_build_tool: rattler-build
 conda_forge_output_validation: true

--- a/pixi.toml
+++ b/pixi.toml
@@ -5,7 +5,7 @@
 
 [workspace]
 name = "anaconda-cli-base-feedstock"
-version = "3.53.3"  # conda-smithy version used to generate this file
+version = "3.54.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/anaconda-cli-base-feedstock"
 authors = ["@conda-forge/anaconda-cli-base"]
 channels = ["conda-forge"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,52 @@
+# -*- mode: toml -*-
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
+
+[workspace]
+name = "anaconda-cli-base-feedstock"
+version = "3.53.3"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/anaconda-cli-base-feedstock"
+authors = ["@conda-forge/anaconda-cli-base"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+requires-pixi = ">=0.59.0"
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build anaconda-cli-base-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build anaconda-cli-base-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of anaconda-cli-base-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,30 +1,35 @@
-{% set name = "anaconda-cli-base" %}
-{% set version = "0.7.0" %}
+schema_version: 1
+
+context:
+  name: anaconda-cli-base
+  version: "0.7.0"
+  python_min: "3.10"
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/anaconda_cli_base-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/anaconda_cli_base-${{ version }}.tar.gz
   sha256: 4ebec5d913039b6ac208a4c6abed737f7ad1f311f54c14b768bd5cb266092207
 
 build:
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
-  number: 0
-  entry_points:
-    - anaconda = anaconda_cli_base.cli:app
+  script: ${{ PYTHON }} -m pip install . -vv
+  python:
+    entry_points:
+      - anaconda = anaconda_cli_base.cli:app
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - hatchling
     - hatch-vcs >=0.3
     - setuptools-scm >=7.1
     - pip
   run:
-    - python >={{ python_min }}
+    - python >=${{ python_min }}
     - click
     - readchar
     - rich
@@ -32,7 +37,7 @@ requirements:
     - pydantic-settings >=2.3
     - tomli
     - packaging >=23.0
-  run_constrained:
+  run_constraints:
     # Ensure coordinated rollout of changes related to multi-site configuration
     - anaconda-auth >=0.12.0
     # Ensure that a version of anaconda-cli-base cannot be installed if an incompatible
@@ -40,21 +45,23 @@ requirements:
     - anaconda-client >=1.13.0
     - anaconda-cloud-cli >=0.3.0
 
-test:
-  requires:
-    - python {{ python_min }}
-    - pip
-  imports:
-    - anaconda_cli_base
-  commands:
-    - python -c "from anaconda_cli_base import __version__; assert __version__ == \"{{ version }}\""
-    - pip check
+tests:
+  - python:
+      imports:
+        - anaconda_cli_base
+      pip_check: true
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - python ${{ python_min }}.*
+    script:
+      - python -c "from anaconda_cli_base import __version__; assert __version__ == \"${{ version }}\""
 
 about:
   summary: A base CLI entrypoint supporting Anaconda CLI plugins
-  home: https://github.com/anaconda/anaconda-cli-base
   license: BSD-3-Clause
   license_file: LICENSE
+  homepage: https://github.com/anaconda/anaconda-cli-base
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
* Update to [v1 recipe format](https://conda-forge.org/blog/2025/02/27/conda-forge-v1-recipe-support/).
```
pixi exec conda-recipe-manager convert --output recipe/recipe.yaml .
```
and a bit more tweaks to get around some bugs.
* Set python_min explicitly.
   - Upstream source requires Python 3.9+, but dependencies are forcing Python 3.10+.
* Add rattler-build and pixi as conda tools.
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
